### PR TITLE
Adapt evm-bully for aurora-engine CI

### DIFF
--- a/command/replay.go
+++ b/command/replay.go
@@ -34,6 +34,8 @@ func Replay(argv0 string, args ...string) error {
 	initialBalance := fs.String("initial-balance", defaultInitialBalance, "Number of tokens to transfer to newly created account")
 	release := fs.Bool("release", false, "Run release version of neard (instead of debug version)")
 	setup := fs.Bool("setup", false, "Setup and run neard before replaying (auto-deploys contract)")
+	neardPath := fs.String("neard", "", "Path to neard binary (won't build neard if -setup is provided)")
+	neardHead := fs.String("neardhead", "", "Git hash of neard (required if -neard is provided)")
 	skip := fs.Bool("skip", false, "Skip empty blocks during replay")
 	startBlock := fs.Int("startblock", 0, "Start replaying at this block height")
 	startTx := fs.Int("starttx", 0, "Start replaying at this transaction (in block given by -startblock)")
@@ -82,6 +84,9 @@ func Replay(argv0 string, args ...string) error {
 	}
 	if *contract != "" && !*setup {
 		return errors.New("option -contract requires option -setup")
+	}
+	if *neardPath != "" && *neardHead == "" {
+		return errors.New("option -neard requires option -neardhead")
 	}
 	chainID, testnet, err := testnetFlags.determineTestnet()
 	if err != nil {
@@ -136,6 +141,8 @@ func Replay(argv0 string, args ...string) error {
 		BreakTx:        *breakTx,
 		Release:        *release,
 		Setup:          *setup,
+		NeardPath:      *neardPath,
+		NeardHead:      *neardHead,
 		InitialBalance: *initialBalance,
 		Contract:       *contract,
 		Breakpoint: replayer.Breakpoint{

--- a/command/replay.go
+++ b/command/replay.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/aurora-is-near/evm-bully/replayer"
+	"github.com/aurora-is-near/evm-bully/util/aurora"
 	"github.com/aurora-is-near/near-api-go"
 )
 
@@ -36,6 +37,7 @@ func Replay(argv0 string, args ...string) error {
 	setup := fs.Bool("setup", false, "Setup and run neard before replaying (auto-deploys contract)")
 	neardPath := fs.String("neard", "", "Path to neard binary (won't build neard if -setup is provided)")
 	neardHead := fs.String("neardhead", "", "Git hash of neard (required if -neard is provided)")
+	auroraCliPath := fs.String("auroracli", "aurora", "Path (or alias) to aurora-cli")
 	skip := fs.Bool("skip", false, "Skip empty blocks during replay")
 	startBlock := fs.Int("startblock", 0, "Start replaying at this block height")
 	startTx := fs.Int("starttx", 0, "Start replaying at this transaction (in block given by -startblock)")
@@ -103,6 +105,8 @@ func Replay(argv0 string, args ...string) error {
 			return flag.ErrHelp
 		}
 	}
+
+	aurora.SetAuroraCliPath(*auroraCliPath)
 
 	// determine evmContract
 	var evmContract string

--- a/replayer/neard/neard.go
+++ b/replayer/neard/neard.go
@@ -103,7 +103,7 @@ func Setup(release bool) (*NEARDaemon, error) {
 		return nil, err
 	}
 	// get current HEAD
-	n.Head, err = git.Head()
+	n.Head, err = git.Head(nearDir)
 	if err != nil {
 		return nil, err
 	}

--- a/replayer/replay_tx.go
+++ b/replayer/replay_tx.go
@@ -21,26 +21,13 @@ import (
 
 func buildAuroraEngine(head string) error {
 	fmt.Println("build aurora-engine")
-	// get cwd
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	// switch to aurora-engine directory
-	nearDir := filepath.Join(cwd, "..", "aurora-engine")
-	if err := os.Chdir(nearDir); err != nil {
-		return err
-	}
+	engineDir := filepath.Join("..", "aurora-engine")
 	// checkout
-	if err := git.Checkout(nearDir, head); err != nil {
+	if err := git.Checkout(engineDir, head); err != nil {
 		return err
 	}
 	// build
-	if err := gnumake.Make("evm-bully=yes"); err != nil {
-		return err
-	}
-	// switch back to original directory
-	if err := os.Chdir(cwd); err != nil {
+	if err := gnumake.Make(engineDir, "evm-bully=yes"); err != nil {
 		return err
 	}
 	return nil

--- a/replayer/replay_tx.go
+++ b/replayer/replay_tx.go
@@ -32,7 +32,7 @@ func buildAuroraEngine(head string) error {
 		return err
 	}
 	// checkout
-	if err := git.Checkout(head); err != nil {
+	if err := git.Checkout(nearDir, head); err != nil {
 		return err
 	}
 	// build
@@ -59,7 +59,7 @@ func buildNearcore(head string, release bool) error {
 		return err
 	}
 	// checkout
-	if err := git.Checkout(head); err != nil {
+	if err := git.Checkout(nearDir, head); err != nil {
 		return err
 	}
 	// build

--- a/replayer/replayer.go
+++ b/replayer/replayer.go
@@ -185,12 +185,19 @@ func (r *Replayer) replay(
 	if r.Setup {
 		// setup neard
 		log.Info("setup neard")
-		neard, err := neard.Setup(r.Release)
+		nearDir := filepath.Join("..", "nearcore")
+		nearDaemon, err := neard.LoadFromRepo(nearDir, r.Release, true)
 		if err != nil {
 			return -1, -1, nil, err
 		}
-		defer neard.Stop()
-		r.Breakpoint.NearcoreHead = neard.Head
+		if err := nearDaemon.SetupLocalData(); err != nil {
+			return -1, -1, nil, err
+		}
+		if err := nearDaemon.Start(); err != nil {
+			return -1, -1, nil, err
+		}
+		defer nearDaemon.Stop()
+		r.Breakpoint.NearcoreHead = nearDaemon.Head
 
 		log.Info("sleep")
 		time.Sleep(5 * time.Second)

--- a/replayer/replayer.go
+++ b/replayer/replayer.go
@@ -32,16 +32,18 @@ type Replayer struct {
 	DataDir        string
 	Testnet        string
 	Defrost        bool
-	Skip           bool // skip empty blocks
-	Batch          bool // batch transactions
-	BatchSize      int  // batch size when batching transactions
-	StartBlock     int  // start replaying at this block height
-	StartTx        int  // start replaying at this transaction (in block given by StartBlock)
-	Autobreak      bool // automatically repeat with break point after error
-	BreakBlock     int  // break replaying at this block height
-	BreakTx        int  // break replaying at this transaction (in block given by BreakBlock)
-	Release        bool // run release version of neard
-	Setup          bool // setup and run neard before replaying
+	Skip           bool   // skip empty blocks
+	Batch          bool   // batch transactions
+	BatchSize      int    // batch size when batching transactions
+	StartBlock     int    // start replaying at this block height
+	StartTx        int    // start replaying at this transaction (in block given by StartBlock)
+	Autobreak      bool   // automatically repeat with break point after error
+	BreakBlock     int    // break replaying at this block height
+	BreakTx        int    // break replaying at this transaction (in block given by BreakBlock)
+	Release        bool   // run release version of neard
+	Setup          bool   // setup and run neard before replaying
+	NeardPath      string // path to neard binary
+	NeardHead      string // git hash of neard
 	InitialBalance string
 	Contract       string
 	Breakpoint     Breakpoint
@@ -185,11 +187,18 @@ func (r *Replayer) replay(
 	if r.Setup {
 		// setup neard
 		log.Info("setup neard")
-		nearDir := filepath.Join("..", "nearcore")
-		nearDaemon, err := neard.LoadFromRepo(nearDir, r.Release, true)
+
+		var nearDaemon *neard.NEARDaemon
+		var err error
+		if r.NeardPath != "" {
+			nearDaemon, err = neard.LoadFromBinary(r.NeardPath, r.NeardHead)
+		} else {
+			nearDaemon, err = neard.LoadFromRepo(filepath.Join("..", "nearcore"), r.Release, true)
+		}
 		if err != nil {
 			return -1, -1, nil, err
 		}
+
 		if err := nearDaemon.SetupLocalData(); err != nil {
 			return -1, -1, nil, err
 		}

--- a/replayer/util.go
+++ b/replayer/util.go
@@ -3,7 +3,6 @@ package replayer
 import (
 	"fmt"
 	"math/big"
-	"os"
 	"path/filepath"
 
 	"github.com/aurora-is-near/evm-bully/util/git"
@@ -11,26 +10,12 @@ import (
 )
 
 func auroraEngineHead(contract string) (string, error) {
-	// get cwd
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	fmt.Println(cwd)
-	// switch to aurora-engine directory
-	if err := os.Chdir(filepath.Dir(contract)); err != nil {
-		return "", err
-	}
-	// get current HEAD
-	head, err := git.Head()
+	// get current HEAD in aurora-engine directory
+	head, err := git.Head(filepath.Dir(contract))
 	if err != nil {
 		return "", err
 	}
 	log.Info(fmt.Sprintf("head=%s", head))
-	// switch back to original directory
-	if err := os.Chdir(cwd); err != nil {
-		return "", err
-	}
 	return head, nil
 }
 

--- a/util/aurora/aurora.go
+++ b/util/aurora/aurora.go
@@ -2,6 +2,7 @@
 package aurora
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
@@ -9,6 +10,17 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 )
+
+var auroraCliPath string
+
+func init() {
+	auroraCliPath = "aurora"
+}
+
+// SetAuroraCliPath sets aurora-cli path (or alias)
+func SetAuroraCliPath(path string) {
+	auroraCliPath = path
+}
 
 // Install the EVM contract with given accountID owner and chainID.
 func Install(accountID string, chainID uint8, contract string) error {
@@ -20,8 +32,8 @@ func Install(accountID string, chainID uint8, contract string) error {
 		"--owner", accountID,
 		contract,
 	}
-	log.Info("$ aurora " + strings.Join(args, " "))
-	cmd := exec.Command("aurora", args...)
+	log.Info(fmt.Sprintf("$ %v %v", auroraCliPath, strings.Join(args, " ")))
+	cmd := exec.Command(auroraCliPath, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/util/git/git.go
+++ b/util/git/git.go
@@ -8,9 +8,10 @@ import (
 	"strings"
 )
 
-// Head returns the current Git HEAD in the current working directory.
-func Head() (string, error) {
+// Head returns the current Git HEAD in the repository by given path.
+func Head(repoPath string) (string, error) {
 	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = repoPath
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = os.Stderr
@@ -20,9 +21,10 @@ func Head() (string, error) {
 	return strings.TrimSpace(stdout.String()), nil
 }
 
-// Checkout checks out the given head in the current working directory.
-func Checkout(head string) error {
+// Checkout checks out the given head in the repository by given path.
+func Checkout(repoPath string, head string) error {
 	cmd := exec.Command("git", "checkout", head)
+	cmd.Dir = repoPath
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/util/gnumake/gnumake.go
+++ b/util/gnumake/gnumake.go
@@ -6,9 +6,10 @@ import (
 	"os/exec"
 )
 
-// Make calls make in the current working directory.
-func Make(args ...string) error {
+// Make calls make in the directory by provided path.
+func Make(path string, args ...string) error {
 	cmd := exec.Command("make", args...)
+	cmd.Dir = path
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()


### PR DESCRIPTION
Couple of things are done here:
1. Changing cwd by `os.Chdir` is not necessary, I altered git/make to do the same thing by setting `cmd.Dir` instead
2. Refactored `replayer/neard` quite a lot, to support more flexibility for different usage scenarios
3. Neard binary and aurora-cli paths can now be specified by argument
4. Thousands of empty blocks do not spam logs anymore (combined in ranges)