### PR TITLE
Fix TotalPrepaidGasExceeded error

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -16,7 +16,7 @@ const (
 )
 
 const (
-	defaultGas            = 800000000000000
+	defaultGas            = 300000000000000
 	defaultInitialBalance = "100"
 )
 


### PR DESCRIPTION
Starting from commit [c3d717c](https://github.com/near/nearcore/pull/4795) in nearcore, bully fails to make nearcore call with this amount of total prepaid gas (`8e14`), even though bully [raises this limit](https://github.com/aurora-is-near/evm-bully/blob/master/replayer/neard/neard.go#L141-L144):
```
Server error: map[TxExecutionError:map[InvalidTxError:map[ActionsValidation:map[TotalPrepaidGasExceeded:map[limit:300000000000000 total_prepaid_gas:800000000000000]]]]
```
This PR resets defaultGas constant to `3e14`, which is equal to `max_total_prepaid_gas` by default.