### PR TITLE
Add wait-checks to replayer

### DIFF
--- a/command/state.go
+++ b/command/state.go
@@ -29,7 +29,7 @@ func State(argv0 string, args ...string) error {
 	}
 	accountID := fs.Arg(0)
 	c := near.NewConnection(cfg.NodeURL)
-	res, err := c.State(accountID)
+	res, err := c.GetAccountState(accountID)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aurora-is-near/evm-bully
 go 1.15
 
 require (
-	github.com/aurora-is-near/near-api-go v0.0.9
+	github.com/aurora-is-near/near-api-go v0.0.10-0.20211013200717-c79e31f1bc11
 	github.com/btcsuite/btcd v0.22.0-beta // indirect
 	github.com/ethereum/go-ethereum v1.10.6
 	github.com/frankbraun/codechain v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aurora-is-near/evm-bully
 go 1.15
 
 require (
-	github.com/aurora-is-near/near-api-go v0.0.10-0.20211013200717-c79e31f1bc11
+	github.com/aurora-is-near/near-api-go v0.0.10
 	github.com/btcsuite/btcd v0.22.0-beta // indirect
 	github.com/ethereum/go-ethereum v1.10.6
 	github.com/frankbraun/codechain v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/aurora-is-near/go-jsonrpc v0.0.1 h1:r9mqm5g1IMdUVrVf+mKkunNqPzq4f4L0j
 github.com/aurora-is-near/go-jsonrpc v0.0.1/go.mod h1:xNWlEyKt0KlED2dowDTsPBV4I0uqKfEeeWM7+zrOw2Y=
 github.com/aurora-is-near/near-api-go v0.0.9 h1:/idKPN1nzlATHG77mXqTF0Q3P/rkLHyDP7FzlFSaRvQ=
 github.com/aurora-is-near/near-api-go v0.0.9/go.mod h1:Gy4d/gPk7bOef4T6uZ3vKkL+NeeungafWLjtp1XbsiY=
+github.com/aurora-is-near/near-api-go v0.0.10-0.20211013200717-c79e31f1bc11 h1:ziVldUk1jpMIHKmKB073OYC2OL5JZkgS8/uLFAYJaIE=
+github.com/aurora-is-near/near-api-go v0.0.10-0.20211013200717-c79e31f1bc11/go.mod h1:Gy4d/gPk7bOef4T6uZ3vKkL+NeeungafWLjtp1XbsiY=
 github.com/aws/aws-sdk-go-v2 v1.2.0/go.mod h1:zEQs02YRBw1DjK0PoJv3ygDYOFTre1ejlJWl8FwAuQo=
 github.com/aws/aws-sdk-go-v2/config v1.1.1/go.mod h1:0XsVy9lBI/BCXm+2Tuvt39YmdHwS5unDQmxZOYe8F5Y=
 github.com/aws/aws-sdk-go-v2/credentials v1.1.1/go.mod h1:mM2iIjwl7LULWtS6JCACyInboHirisUUdkBPoTHMOUo=

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/aurora-is-near/near-api-go v0.0.9 h1:/idKPN1nzlATHG77mXqTF0Q3P/rkLHyD
 github.com/aurora-is-near/near-api-go v0.0.9/go.mod h1:Gy4d/gPk7bOef4T6uZ3vKkL+NeeungafWLjtp1XbsiY=
 github.com/aurora-is-near/near-api-go v0.0.10-0.20211013200717-c79e31f1bc11 h1:ziVldUk1jpMIHKmKB073OYC2OL5JZkgS8/uLFAYJaIE=
 github.com/aurora-is-near/near-api-go v0.0.10-0.20211013200717-c79e31f1bc11/go.mod h1:Gy4d/gPk7bOef4T6uZ3vKkL+NeeungafWLjtp1XbsiY=
+github.com/aurora-is-near/near-api-go v0.0.10 h1:q4qDbvHWrt9MgJeqhTHBUy7gpQc2gdPF0pn4VTGHghw=
+github.com/aurora-is-near/near-api-go v0.0.10/go.mod h1:Gy4d/gPk7bOef4T6uZ3vKkL+NeeungafWLjtp1XbsiY=
 github.com/aws/aws-sdk-go-v2 v1.2.0/go.mod h1:zEQs02YRBw1DjK0PoJv3ygDYOFTre1ejlJWl8FwAuQo=
 github.com/aws/aws-sdk-go-v2/config v1.1.1/go.mod h1:0XsVy9lBI/BCXm+2Tuvt39YmdHwS5unDQmxZOYe8F5Y=
 github.com/aws/aws-sdk-go-v2/credentials v1.1.1/go.mod h1:mM2iIjwl7LULWtS6JCACyInboHirisUUdkBPoTHMOUo=

--- a/replayer/create_account.go
+++ b/replayer/create_account.go
@@ -47,7 +47,7 @@ func (ca *CreateAccount) Create(accountID string) error {
 	}
 
 	// check to see if account already exists
-	_, err = c.State(accountID)
+	_, err = c.GetAccountState(accountID)
 	if err == nil {
 		return fmt.Errorf("sorry, account '%s' already exists", accountID)
 	} else if !strings.Contains(err.Error(), "does not exist while viewing") {

--- a/replayer/util.go
+++ b/replayer/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"path/filepath"
+	"time"
 
 	"github.com/aurora-is-near/evm-bully/util/git"
 	"github.com/ethereum/go-ethereum/log"
@@ -41,4 +42,15 @@ func bigIntToRawU256(b *big.Int) (RawU256, error) {
 	// the encoding is already big-endian
 	copy(res[:], bytes[:])
 	return res, nil
+}
+
+func checkUntilTrue(timeout time.Duration, msg string, predicate func() bool) bool {
+	for start := time.Now(); time.Since(start) < timeout; {
+		if predicate() {
+			return true
+		}
+		log.Info(fmt.Sprintf("%v, sleeping for 1 second...", msg))
+		time.Sleep(time.Second)
+	}
+	return false
 }


### PR DESCRIPTION
Instead of sleeping, make replayer wait for:
1. Near node start and listening
2. Account creation
3. Contract installation

Needs this PR to be merged: https://github.com/aurora-is-near/near-api-go/pull/2
After it's merged, `go.mod` has to be updated accordingly