### PR TITLE
Speed up neard block production

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/aurora-is-near/near-api-go v0.0.10
 	github.com/btcsuite/btcd v0.22.0-beta // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/ethereum/go-ethereum v1.10.6
 	github.com/frankbraun/codechain v1.2.0
 	github.com/near/borsh-go v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku
 github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=

--- a/replayer/neard/neard.go
+++ b/replayer/neard/neard.go
@@ -2,7 +2,6 @@
 package neard
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -122,31 +121,28 @@ func (daemon *NEARDaemon) init() error {
 	return cmd.Run()
 }
 
-func (daemon *NEARDaemon) editGenesis() error {
-	filename := filepath.Join(daemon.localDir, "genesis.json")
-	backup := filepath.Join(daemon.localDir, "genesis_old.json")
+func (daemon *NEARDaemon) editConfig() error {
+	filename := filepath.Join(daemon.localDir, "config.json")
+	backup := filepath.Join(daemon.localDir, "config_old.json")
 	if err := file.Copy(filename, backup); err != nil {
 		return err
 	}
-	// read file
-	data, err := os.ReadFile(filename)
-	if err != nil {
-		return err
+
+	edits := []*jsonEdit{
+		{[]string{"rpc", "polling_config", "polling_interval", "secs"}, "0"},
+		{[]string{"rpc", "polling_config", "polling_interval", "nanos"}, "5000000"},
+		{[]string{"consensus", "block_production_tracking_delay", "secs"}, "0"},
+		{[]string{"consensus", "block_production_tracking_delay", "nanos"}, "10000000"},
+		{[]string{"consensus", "min_block_production_delay", "secs"}, "0"},
+		{[]string{"consensus", "min_block_production_delay", "nanos"}, "10000000"},
+		{[]string{"consensus", "max_block_production_delay", "secs"}, "0"},
+		{[]string{"consensus", "max_block_production_delay", "nanos"}, "50000000"},
+		{[]string{"consensus", "catchup_step_period", "secs"}, "0"},
+		{[]string{"consensus", "catchup_step_period", "nanos"}, "10000000"},
+		{[]string{"consensus", "doomslug_step_period", "secs"}, "0"},
+		{[]string{"consensus", "doomslug_step_period", "nanos"}, "10000000"},
 	}
-	// change default values the brute force way, neard chokes on edited JSON
-	data = bytes.Replace(data,
-		[]byte("\"max_gas_burnt\": 200000000000000"),
-		[]byte("\"max_gas_burnt\": 800000000000000"),
-		1)
-	data = bytes.Replace(data,
-		[]byte("\"max_total_prepaid_gas\": 300000000000000"),
-		[]byte("\"max_total_prepaid_gas\": 800000000000000"),
-		1)
-	// write file
-	if err := os.WriteFile(filename, data, 0644); err != nil {
-		return err
-	}
-	return nil
+	return editJsonFile(filename, edits)
 }
 
 // SetupLocalData initializes local data of a NEARDaemon.
@@ -163,7 +159,7 @@ func (daemon *NEARDaemon) SetupLocalData() error {
 	}
 
 	// edit genesis.json
-	if err := daemon.editGenesis(); err != nil {
+	if err := daemon.editConfig(); err != nil {
 		return err
 	}
 

--- a/replayer/neard/neard.go
+++ b/replayer/neard/neard.go
@@ -142,7 +142,7 @@ func (daemon *NEARDaemon) editConfig() error {
 		{[]string{"consensus", "doomslug_step_period", "secs"}, "0"},
 		{[]string{"consensus", "doomslug_step_period", "nanos"}, "10000000"},
 	}
-	return editJsonFile(filename, edits)
+	return editJSONFile(filename, edits)
 }
 
 // SetupLocalData initializes local data of a NEARDaemon.

--- a/replayer/neard/utils.go
+++ b/replayer/neard/utils.go
@@ -11,7 +11,7 @@ type jsonEdit struct {
 	Value string
 }
 
-func editJsonFile(filename string, edits []*jsonEdit) error {
+func editJSONFile(filename string, edits []*jsonEdit) error {
 	data, err := os.ReadFile(filename)
 	if err != nil {
 		return err

--- a/replayer/neard/utils.go
+++ b/replayer/neard/utils.go
@@ -1,0 +1,29 @@
+package neard
+
+import (
+	"os"
+
+	"github.com/buger/jsonparser"
+)
+
+type jsonEdit struct {
+	Path  []string
+	Value string
+}
+
+func editJsonFile(filename string, edits []*jsonEdit) error {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+	for _, edit := range edits {
+		data, err = jsonparser.Set(data, []byte(edit.Value), edit.Path...)
+		if err != nil {
+			return err
+		}
+	}
+	if err := os.WriteFile(filename, data, 0644); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
1. Genesis editing is no longer needed (`max_gas_burnt` and `max_total_prepaid_gas` don't exist anymore, and gas doesn't seem to be the problem anymore)
2. Neard-config is tuned to increase speed of block production. As a result, transaction submit now takes ~100ms instead of ~2000ms